### PR TITLE
🧹 Refactor Links component to remove magic number

### DIFF
--- a/src/components/Links.tsx
+++ b/src/components/Links.tsx
@@ -13,22 +13,20 @@ type LinksProps = {
 	}[]
 }
 
-const MENU_HOVER_INDEX = 114514
-
 export function Links({ links }: LinksProps) {
-	const [isHoverIndex, setIsHoverIndex] = useState(-1)
+	const [hoverIndex, setHoverIndex] = useState<number | 'menu' | null>(null)
 	const [isMenuOpen, setIsMenuOpen] = useState(false)
 
 	return (
-		<div className="relative flex" onMouseLeave={() => setIsHoverIndex(-1)}>
+		<div className="relative flex" onMouseLeave={() => setHoverIndex(null)}>
 			{links.map((link, index) => {
 				return (
 					<Button
 						aria-label={link.name}
 						key={link.name}
 						icon={link.icon}
-						active={isHoverIndex === index}
-						onHover={() => setIsHoverIndex(index)}
+						active={hoverIndex === index}
+						onHover={() => setHoverIndex(index)}
 						href={link.url}
 					/>
 				)
@@ -37,10 +35,10 @@ export function Links({ links }: LinksProps) {
 			<Button
 				icon="menu"
 				onHover={() => {
-					setIsHoverIndex(MENU_HOVER_INDEX)
+					setHoverIndex('menu')
 				}}
 				onTap={() => setIsMenuOpen(!isMenuOpen)}
-				active={isHoverIndex === MENU_HOVER_INDEX}
+				active={hoverIndex === 'menu'}
 			/>
 
 			<Menu isOpen={isMenuOpen} menus={menus} />


### PR DESCRIPTION
🎯 **What:** The `Links` component used a magic number `114514` (as `MENU_HOVER_INDEX`) and `-1` to track the hover state. This was refactored to use a union type `number | 'menu' | null`.

💡 **Why:** This improves maintainability and readability by using descriptive values instead of arbitrary integers. It also leverages TypeScript's type system to ensure correctness.

✅ **Verification:** Manually reviewed the code changes to ensure logical consistency. No functional behavior was changed.

✨ **Result:** A cleaner, more type-safe `Links` component.

---
*PR created automatically by Jules for task [5232186128780359195](https://jules.google.com/task/5232186128780359195) started by @Cookiekira*